### PR TITLE
Move nodejs to nodesource

### DIFF
--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -55,10 +55,9 @@
     name: jupyterhub
     executable: pip3.6
 
-- name: Install node packages
-  yum:
+- name: Install NodeJS
+  include_role:
     name: nodejs
-    state: present
 
 - name: Install configurable-http-proxy
   npm:

--- a/ansible/roles/roles_requirements.yml
+++ b/ansible/roles/roles_requirements.yml
@@ -20,3 +20,7 @@
 - name: sudo
   src:  https://github.com/weareinteractive/ansible-sudo
   version: 1.7.1
+
+- name: nodejs
+  src: https://github.com/geerlingguy/ansible-role-nodejs
+  version: 5.1.1 

--- a/ansible/scripts/role_module_update.sh
+++ b/ansible/scripts/role_module_update.sh
@@ -52,25 +52,4 @@ fi
 # Install roles
 ansible-galaxy install -r "$ROLES_REQUIREMENTS_FILE" --force --no-deps -p "$EXTERNAL_ROLE_DIR"
 
-## Libraries
-
-# Check library req file
-[[ ! -f "$LIBRARY_REQUIREMENTS_FILE" ]]  && msg_exit "library_requirements '$LIBRARY_REQUIREMENTS_FILE' does not exist or permssion issue.\nPlease check and rerun."
-
-# Remove existing libraries
-if [ -d "$EXTERNAL_LIBRARY_DIR" ]; then
-    cd "$EXTERNAL_LIBRARY_DIR"
-    if [ "$(pwd)" == "$EXTERNAL_LIBRARY_DIR" ];then
-      echo "Removing current roles in '$EXTERNAL_LIBRARY_DIR/*'"
-      rm -rf *
-    else
-      msg_exit "Path error could not change dir to $EXTERNAL_LIBRARY_DIR"
-    fi
-fi
-
-
-
-# Install libraries
-ansible-galaxy install -r "$LIBRARY_REQUIREMENTS_FILE" --force --no-deps -p "$EXTERNAL_LIBRARY_DIR"
-
 exit 0


### PR DESCRIPTION
**Untested, don't merge yet**

We need to move node to a later version and this role does the job. To use it run `./ansible/scripts/role_module_update.sh` to grab the updated role, then re-run the hub play. When it is finished it should install node 12.x.
