### PR TITLE
Use created_at instead of updated_at for student reg_date.

### DIFF
--- a/rudaux/course_api.py
+++ b/rudaux/course_api.py
@@ -93,7 +93,7 @@ def _canvas_get_people_by_type(config, course_id, typ):
                'name' : p['user']['name'],
                'sortable_name' : p['user']['sortable_name'],
                'school_id' : str(p['user']['sis_user_id']),
-               'reg_date' : plm.parse(p['updated_at']) if (plm.parse(p['updated_at']) is not None) else plm.parse(p['created_at']),
+               'reg_date' : plm.parse(p['created_at']) if (plm.parse(p['created_at']) is not None) else plm.parse(p['updated_at']),
                'status' : p['enrollment_state']
               } for p in ppl_typ
            ]


### PR DESCRIPTION
'updated_at' date on Canvas for all students was set to a date past the open date of the first assignment, which caused all students to get a late registration extension.

Change 'reg_date' to default to 'created_at' as it seems to reflect the actual registration date of the student better.

Tested on dsci-100-instructor-py.stat.ubc.ca and appears to be functioning correctly (giving extensions only to late registrants).