### PR TITLE
Paramiko hanging fix

### DIFF
--- a/rudaux/snapshot.py
+++ b/rudaux/snapshot.py
@@ -39,7 +39,7 @@ def _ssh_open(config, course_id):
     client.set_missing_host_key_policy(pmk.client.AutoAddPolicy())
     client.load_system_host_keys()
     client.connect(stu_ssh['hostname'], stu_ssh['port'], stu_ssh['user'], allow_agent=True)
-    s = client.get_transport().open_session()
+    s = client.get_transport().open_session(window_size=1000000,max_packet_size=65536)
     pmk.agent.AgentRequestHandler(s)
     # TODO error handling
     return client

--- a/rudaux/snapshot.py
+++ b/rudaux/snapshot.py
@@ -65,12 +65,10 @@ def _ssh_command(client, cmd):
     stdout_lines = []
     for line in stdout:
         stdout_lines.append(line)
-    stdout = stdout_lines
 
     stderr_lines = []
     for line in stderr:
         stderr_lines.append(line)
-    stderr = stderr_lines
 
     # get exit status
     out_status = stdout.channel.recv_exit_status()
@@ -87,7 +85,7 @@ def _ssh_command(client, cmd):
         raise sig
 
     # return
-    return stdout, stderr
+    return stdout_lines, stderr_lines
 
 def _ssh_snapshot(config, course_id, snap_path):
     logger = get_logger()

--- a/rudaux/snapshot.py
+++ b/rudaux/snapshot.py
@@ -50,12 +50,6 @@ def _ssh_command(client, cmd):
     # execute the snapshot command
     stdin, stdout, stderr = client.exec_command(cmd)
 
-    # block on result
-    out_status = stdout.channel.recv_exit_status()
-    err_status = stderr.channel.recv_exit_status()
-
-    logger.info(f"Command exit codes: out = {out_status}  err = {err_status}")
-
     # get output
     stdout_lines = []
     for line in stdout:
@@ -66,6 +60,12 @@ def _ssh_command(client, cmd):
     for line in stderr:
         stderr_lines.append(line)
     stderr = stderr_lines
+
+    # block on result
+    out_status = stdout.channel.recv_exit_status()
+    err_status = stderr.channel.recv_exit_status()
+
+    logger.info(f"Command exit codes: out = {out_status}  err = {err_status}")
 
     if out_status != 0 or err_status != 0:
         msg = f"Paramiko SSH command error: nonzero status.\nstderr\n{stderr}\nstdout\n{stdout}"

--- a/rudaux/snapshot.py
+++ b/rudaux/snapshot.py
@@ -1,6 +1,5 @@
 import os
 import prefect
-import time
 from prefect import task
 from prefect.engine import signals
 import paramiko as pmk
@@ -51,16 +50,6 @@ def _ssh_command(client, cmd):
     # execute the snapshot command
     stdin, stdout, stderr = client.exec_command(cmd)
 
-    # poll until command has finished executing
-    timeout = 900 # seconds
-    start_time = time.time()
-    while not exit_status_ready():
-        if time.time() - start_time > timeout:
-            msg = f"Paramiko SSH command error: Wait for command execution has exceeded timeout"
-            sig = RuntimeError(msg)
-            sig.msg = msg
-            raise sig
-
     # get output
     stdout_lines = []
     for line in stdout:
@@ -70,7 +59,7 @@ def _ssh_command(client, cmd):
     for line in stderr:
         stderr_lines.append(line)
 
-    # get exit status
+    # block on result
     out_status = stdout.channel.recv_exit_status()
     err_status = stderr.channel.recv_exit_status()
 

--- a/rudaux/snapshot.py
+++ b/rudaux/snapshot.py
@@ -54,7 +54,7 @@ def _ssh_command(client, cmd):
     # poll until command has finished executing
     timeout = 900 # seconds
     start_time = time.time()
-    while not stdout.channel.exit_status_ready() and stderr.channel.exit_status_ready():
+    while not exit_status_ready():
         if time.time() - start_time > timeout:
             msg = f"Paramiko SSH command error: Wait for command execution has exceeded timeout"
             sig = RuntimeError(msg)

--- a/rudaux/snapshot.py
+++ b/rudaux/snapshot.py
@@ -54,7 +54,7 @@ def _ssh_command(client, cmd):
     # poll until command has finished executing
     timeout = 900 # seconds
     start_time = time.time()
-    while not exit_status_ready():
+    while not stdout.channel.exit_status_ready() and stderr.channel.exit_status_ready():
         if time.time() - start_time > timeout:
             msg = f"Paramiko SSH command error: Wait for command execution has exceeded timeout"
             sig = RuntimeError(msg)


### PR DESCRIPTION
I found that the snapshot flow would stop and hang when it tried to receive the exit status from stdout and stderr when collecting the output of `zfs list -t snapshot`, preventing any new snapshots from being taken.

This happens when the output gets over a certain number of lines, I believe in our case it's because rudaux is now taking four times the number of snapshots it used to because of the section overrides. At the time the hanging started, around 20000 snapshots had been taken.

The issue is described [here](https://github.com/paramiko/paramiko/issues/448) and is also described in a warning on the documentation [here](https://docs.paramiko.org/en/latest/api/channel.html#paramiko.channel.Channel.recv_exit_status), I increased the window_size and max_packet_size and moved checking exit status until after reading stdout and stderr as recommended in the comments and warning. ~~Also added polling on exit_status_ready to make sure command finished executing before reading stdout and stderr.~~

rudaux on dsci-100-instructor has been running with these changes for the last three weeks and snapshots are now being taken properly again.